### PR TITLE
fix: update booking form hook import and remove unused hall images

### DIFF
--- a/client/src/pages/Booking/BookingFormPage.js
+++ b/client/src/pages/Booking/BookingFormPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import moment from 'moment';
-import { useBookingForm } from '../../hooks/Booking/useBookings';
+import { useBookingForm } from '../../hooks/Booking/useBookingFormFixed';
 import BookingBasicInfoAnt from '../../components/features/Booking/BookingBasicInfoAnt';
 import { Form, Button, Steps, message, Typography, Spin, Alert, Input, Tabs, Table, InputNumber } from 'antd';
 import { FormattedPrice } from '../../components/common/FormattedPrice';


### PR DESCRIPTION
This pull request includes a small change to the `BookingFormPage.js` file. The change updates the import statement to use the corrected `useBookingFormFixed` hook instead of the previous `useBookingForm` hook.